### PR TITLE
Fix clang-cl on windows compilation

### DIFF
--- a/src/rdendian.h
+++ b/src/rdendian.h
@@ -111,14 +111,24 @@
 #endif
 
 #elif defined(_WIN32)
-#include <intrin.h>
-
-#define be64toh(x) _byteswap_uint64(x)
-#define be32toh(x) _byteswap_ulong(x)
-#define be16toh(x) _byteswap_ushort(x)
 #define le16toh(x) (x)
 #define le32toh(x) (x)
 #define le64toh(x) (x)
+
+#if defined(__clang__)
+/* Clang on windows masquerades as MSVC
+ * but has strange behaviours with handling simd intrinsics
+ * fortunatly it understands bswap builtins which is what we want
+ */
+#define be64toh(x) __builtin_bswap64(x)
+#define be32toh(x) __builtin_bswap32(x)
+#define be16toh(x) __builtin_bswap15(x)
+#else
+#include <intrin.h>
+#define be64toh(x) _byteswap_uint64(x)
+#define be32toh(x) _byteswap_ulong(x)
+#define be16toh(x) _byteswap_ushort(x)
+#endif
 
 #elif defined _AIX      /* AIX is always big endian */
 #define be64toh(x) (x)

--- a/src/snappy.c
+++ b/src/snappy.c
@@ -210,7 +210,7 @@ u64 rd_ctz64(u64 x) {
    y = x << 1;  if (y != 0) {n = n - 1;}
    return n;
 }
-#elif !defined(_MSC_VER)
+#elif defined(__clang__) || !defined(_MSC_VER)
 #define rd_clz(n)   __builtin_clz(n)
 #define rd_ctz(n)   __builtin_ctz(n)
 #define rd_ctz64(n) __builtin_ctzll(n)


### PR DESCRIPTION
Clang when run as clang-cl on windows has subtle issues with SIMD intrinsics. Essentially it tries to parse its own headers but gets confused about the handling of none standard `__attribute__` markers. This leads it to confuse the meaning of certain SIMD types.

Fortunately librdkafka (and snappy as embedded) only need some basic operations that clang (even as clang-cl` support). As such we can use the builtins